### PR TITLE
Output stdout of the executed command to os.Stdout when failed.

### DIFF
--- a/gotesplit.go
+++ b/gotesplit.go
@@ -66,6 +66,7 @@ func getTestListsFromPkgs(pkgs []string) ([]testList, error) {
 	c.Stdout = buf
 	c.Stderr = os.Stderr
 	if err := c.Run(); err != nil {
+		buf.WriteTo(os.Stdout)
 		return nil, err
 	}
 	return getTestLists(buf.String()), nil


### PR DESCRIPTION
Currently, stdout of `go test -list . pkg...` is vanished when the command failed.
I want to get the outputs for debugging.