### PR TITLE
fix: listing tests with tags

### DIFF
--- a/gotesplit.go
+++ b/gotesplit.go
@@ -61,11 +61,11 @@ Options:
 }
 
 func getTestListsFromPkgs(pkgs []string, tags string) ([]testList, error) {
-	args := []string{"test", "-list"}
+	args := []string{"test", "-list", "."}
 	if tags != "" {
 		args = append(args, tags)
 	}
-	args = append(append(args, "."), pkgs...)
+	args = append(args, pkgs...)
 	buf := &bytes.Buffer{}
 	c := exec.Command("go", args...)
 	c.Stdout = buf

--- a/gotesplit_test.go
+++ b/gotesplit_test.go
@@ -1,6 +1,7 @@
 package gotesplit
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -121,5 +122,29 @@ func TestDetectTags(t *testing.T) {
 				t.Errorf("got: %s, expect: %s", out, tc.expect)
 			}
 		})
+	}
+}
+
+func TestGetTestListFromPkgs(t *testing.T) {
+	if err := os.Chdir("testdata/withtags"); err != nil {
+		wd, _ := os.Getwd()
+		t.Fatalf("unexpected error: %v, cwd: %s", err, wd)
+	}
+
+	expect := []testList{{
+		pkg: "github.com/Songmu/gotesplit/testdata/withtags",
+		list: []string{
+			"TestNoTag",
+			"TestTagA",
+		},
+	}}
+
+	got, err := getTestListsFromPkgs([]string{"."}, "-tags=a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(expect, got) {
+		t.Errorf("expect: %#v\ngot: %#v", expect, got)
 	}
 }

--- a/testdata/withtags/go.mod
+++ b/testdata/withtags/go.mod
@@ -1,0 +1,3 @@
+module github.com/Songmu/gotesplit/testdata/withtags
+
+go 1.18

--- a/testdata/withtags/notag_test.go
+++ b/testdata/withtags/notag_test.go
@@ -1,0 +1,5 @@
+package withtags
+
+import "testing"
+
+func TestNoTag(t *testing.T) {}

--- a/testdata/withtags/tag_a_test.go
+++ b/testdata/withtags/tag_a_test.go
@@ -1,0 +1,7 @@
+//go:build a
+
+package withtags
+
+import "testing"
+
+func TestTagA(t *testing.T) {}


### PR DESCRIPTION
when use with `-tags=a`, `go test -list -tags=a . ${pkgs}` is executed.
but `go test -list . -tags=a ${pkgs}` is correct
