### PR TITLE
perf: tags option always placed at testOpts

### DIFF
--- a/run.go
+++ b/run.go
@@ -51,7 +51,7 @@ func run(ctx context.Context, total, idx uint, junitDir string, argv []string, o
 		}
 	}
 
-	testLists, err := getTestListsFromPkgs(pkgs, detectTags(argv))
+	testLists, err := getTestListsFromPkgs(pkgs, detectTags(testOpts))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
-tags option always placed at after --, so it's always included at testOpts
when pkg list is very long, this patch may make gotesplit faster
