### PR TITLE
Use jstemmer/go-junit-report/v2 to correctly parse the output of go test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/Songmu/gotesplit
 go 1.18
 
 require (
-	github.com/jstemmer/go-junit-report v1.0.0
+	github.com/jstemmer/go-junit-report/v2 v2.0.0
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/jstemmer/go-junit-report v1.0.0 h1:8X1gzZpR+nVQLAht+L/foqOeX2l9DTZoaIPbEQHxsds=
-github.com/jstemmer/go-junit-report v1.0.0/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
+github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Use jstemmer/go-junit-report/v2 to correctly parse go test output.

## Problem
jstemmer/go-junit-report(v1) may not parse output correctly. For example, if I try to parse the following output, I want all the output to be put in the failure message, but only the first line is actually put in. The following output is generated by github.com/stretchr/testify/assert.

```
=== RUN   TestGetTestListFromPkgs
    /Users/shibayu36/development/src/github.com/Songmu/gotesplit/gotesplit_test.go:149:
        	Error Trace:	/Users/shibayu36/development/src/github.com/Songmu/gotesplit/gotesplit_test.go:149
        	Error:      	Should not be: []gotesplit.testList{gotesplit.testList{pkg:"github.com/Songmu/gotesplit/testdata/withtags", list:[]string{"TestNoTag", "TestTagA"}}}
        	Test:       	TestGetTestListFromPkgs
--- FAIL: TestGetTestListFromPkgs (0.20s)
FAIL
FAIL	github.com/Songmu/gotesplit	0.287s
```

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
	<testsuite tests="1" failures="1" time="0.287" name="github.com/Songmu/gotesplit">
		<properties>
			<property name="go.version" value="go1.21.0"></property>
		</properties>
		<testcase classname="gotesplit" name="TestGetTestListFromPkgs" time="0.200">
			<failure message="Failed" type="">    /Users/shibayu36/development/src/github.com/Songmu/gotesplit/gotesplit_test.go:149:</failure>
		</testcase>
	</testsuite>
</testsuites>
```

## Solution by PR

jstemmer/go-junit-report/v2 can correctly parse output. It outputs the following when it parses the same content above.

```
<testsuites tests="1" failures="1">
	<testsuite name="github.com/Songmu/gotesplit" tests="1" failures="1" errors="0" id="0" time="0.287" timestamp="2023-08-20T08:55:15+09:00">
		<testcase name="TestGetTestListFromPkgs" classname="github.com/Songmu/gotesplit" time="0.200">
			<failure message="Failed"><![CDATA[    /Users/shibayu36/development/src/github.com/Songmu/gotesplit/gotesplit_test.go:149:
        	Error Trace:	/Users/shibayu36/development/src/github.com/Songmu/gotesplit/gotesplit_test.go:149
        	Error:      	Should not be: []gotesplit.testList{gotesplit.testList{pkg:"github.com/Songmu/gotesplit/testdata/withtags", list:[]string{"TestNoTag", "TestTagA"}}}
        	Test:       	TestGetTestListFromPkgs]]></failure>
		</testcase>
	</testsuite>
</testsuites>
```
