### PR TITLE
merge coverprofiles instead of overwriting them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/Songmu/gotesplit
 
-go 1.21
+go 1.23
 
 require (
-	github.com/jstemmer/go-junit-report/v2 v2.0.0
-	golang.org/x/sync v0.3.0
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
+	golang.org/x/sync v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/jstemmer/go-junit-report/v2 v2.0.0 h1:bMZNO9B16VFn07tKyi4YJFIbZtVmJaa5Xakv9dcwK58=
-github.com/jstemmer/go-junit-report/v2 v2.0.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/gotesplit.go
+++ b/gotesplit.go
@@ -40,6 +40,7 @@ Options:
 	total := fs.Uint("total", 1, "total number of test splits (CIRCLE_NODE_TOTAL is used if set)")
 	index := fs.Uint("index", 0, "zero-based index number of test splits (CIRCLE_NODE_INDEX is used if set)")
 	junitDir := fs.String("junit-dir", "", "directory to store test result in JUnit format")
+	coverageDir := fs.String("coverprofile-dir", ".cover", "directory to store granular coverprofiles")
 	fs.VisitAll(func(f *flag.Flag) {
 		if f.Name == "index" || f.Name == "total" {
 			if s := os.Getenv("CIRCLE_NODE_" + strings.ToUpper(f.Name)); s != "" {
@@ -57,7 +58,7 @@ Options:
 			return rnr.run(ctx, argv[1:], outStream, errStream)
 		}
 	}
-	return run(ctx, *total, *index, *junitDir, argv, outStream, errStream)
+	return run(ctx, *total, *index, *junitDir, *coverageDir, argv, outStream, errStream)
 }
 
 func getTestListsFromPkgs(pkgs []string, tags string, withRace bool) ([]testList, error) {

--- a/gotesplit.go
+++ b/gotesplit.go
@@ -40,7 +40,7 @@ Options:
 	total := fs.Uint("total", 1, "total number of test splits (CIRCLE_NODE_TOTAL is used if set)")
 	index := fs.Uint("index", 0, "zero-based index number of test splits (CIRCLE_NODE_INDEX is used if set)")
 	junitDir := fs.String("junit-dir", "", "directory to store test result in JUnit format")
-	coverageDir := fs.String("coverprofile-dir", ".cover", "directory to store granular coverprofiles")
+	coverprofileDir := fs.String("coverprofile-dir", ".cover", "temporary directory for collecting coverprofile")
 	fs.VisitAll(func(f *flag.Flag) {
 		if f.Name == "index" || f.Name == "total" {
 			if s := os.Getenv("CIRCLE_NODE_" + strings.ToUpper(f.Name)); s != "" {
@@ -58,7 +58,7 @@ Options:
 			return rnr.run(ctx, argv[1:], outStream, errStream)
 		}
 	}
-	return run(ctx, *total, *index, *junitDir, *coverageDir, argv, outStream, errStream)
+	return run(ctx, *total, *index, *junitDir, *coverprofileDir, argv, outStream, errStream)
 }
 
 func getTestListsFromPkgs(pkgs []string, tags string, withRace bool) ([]testList, error) {


### PR DESCRIPTION
This change will save coverprofiles in a separate folder and merge them together at the end. Currently the coverprofile gets overwriten by each go test run.