### PR TITLE
Add -list-mode=ast for AST-based test enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ gotesplit splits the testng in Go into a subset and run it
 go test -v -short -run ^(?:TestAA|TestBB)$
 ```
 
+### -list-mode
+
+`-list-mode` selects how `gotesplit` enumerates test names:
+
+- `gotest` (default): runs `go test -list .`, which compiles each package and executes `TestMain`.
+- `ast`: parses each `_test.go` statically with `go/ast` and `go/doc.Examples`. No compilation, so it tends to be faster on large codebases.
+
+```
+gotesplit -list-mode=ast -total=10 -index=0 ./... -- -short
+```
+
+The flag also applies to the `regexp` subcommand:
+
+```
+gotesplit -list-mode=ast regexp 10 0 ./...
+```
+
 ## Description
 
 The gotesplit splits the testng in Go into a subset and run it.

--- a/ast_list.go
+++ b/ast_list.go
@@ -1,0 +1,184 @@
+package gotesplit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type goListPkg struct {
+	ImportPath   string
+	Dir          string
+	TestGoFiles  []string
+	XTestGoFiles []string
+	Incomplete   bool
+	Error        *goListError
+}
+
+type goListError struct {
+	Err string
+}
+
+func runGoList(pkgs []string, tags string, withRace bool) ([]goListPkg, error) {
+	args := []string{"list", "-json", "-e"}
+	if tags != "" {
+		args = append(args, tags)
+	}
+	if withRace {
+		args = append(args, "-race")
+	}
+	args = append(args, pkgs...)
+	cmd := exec.Command("go", args...)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("go list failed: %w: %s", err, stderr.String())
+	}
+	dec := json.NewDecoder(stdout)
+	var result []goListPkg
+	for {
+		var p goListPkg
+		if err := dec.Decode(&p); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("decode go list output: %w", err)
+		}
+		result = append(result, p)
+	}
+	return result, nil
+}
+
+// starSuffix returns the trailing type name "X" from *X or *foo.X.
+func starSuffix(ptr *ast.StarExpr) (string, bool) {
+	switch x := ptr.X.(type) {
+	case *ast.Ident:
+		return x.Name, true
+	case *ast.SelectorExpr:
+		return x.Sel.Name, true
+	}
+	return "", false
+}
+
+// isTestFunc reports whether fn should be picked up as a shard-eligible test.
+// The logic mirrors cmd/go isTestFunc:
+// https://github.com/golang/go/blob/master/src/cmd/go/internal/load/test.go#L551
+func isTestFunc(fn *ast.FuncDecl) bool {
+	name := fn.Name.Name
+	if !strings.HasPrefix(name, "Test") {
+		return false
+	}
+	suffix := name[len("Test"):]
+	if suffix == "" {
+		return false
+	}
+	if r, _ := utf8.DecodeRuneInString(suffix); unicode.IsLower(r) {
+		return false
+	}
+	// Signature check: func(t *<X>.T) — no return value, exactly one parameter (one name), of pointer type *<X>.T.
+	if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 {
+		return false
+	}
+	params := fn.Type.Params
+	if params == nil || len(params.List) != 1 || len(params.List[0].Names) > 1 {
+		return false
+	}
+	ptr, ok := params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	typeName, ok := starSuffix(ptr)
+	return ok && typeName == "T"
+}
+
+func extractTestNames(dir string, testGoFiles, xTestGoFiles []string) ([]string, error) {
+	fset := token.NewFileSet()
+	var files []*ast.File
+	all := append([]string{}, testGoFiles...)
+	all = append(all, xTestGoFiles...)
+	for _, name := range all {
+		path := filepath.Join(dir, name)
+		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		files = append(files, f)
+	}
+
+	var names []string
+
+	// TestXXX
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if fn.Recv != nil {
+				continue // skip methods
+			}
+			if isTestFunc(fn) {
+				names = append(names, fn.Name.Name)
+			}
+		}
+	}
+
+	// ExampleXXX
+	// https://github.com/golang/go/blob/master/src/cmd/go/internal/load/test.go#L755-L764
+	for _, ex := range doc.Examples(files...) {
+		if ex.Output == "" && !ex.EmptyOutput {
+			continue
+		}
+		names = append(names, "Example"+ex.Name)
+	}
+	return names, nil
+}
+
+func getTestListsFromPkgsAST(pkgs []string, tags string, withRace bool) ([]testList, error) {
+	// Delegate package path resolution and build tag evaluation to the Go toolchain by invoking `go list -json` internally.
+	infos, err := runGoList(pkgs, tags, withRace)
+	if err != nil {
+		return nil, err
+	}
+	var lists []testList
+	for _, p := range infos {
+		if p.Error != nil {
+			return nil, fmt.Errorf("go list %s: %s", p.ImportPath, p.Error.Err)
+		}
+		if p.Incomplete {
+			return nil, fmt.Errorf("go list %s: incomplete package info", p.ImportPath)
+		}
+		if len(p.TestGoFiles) == 0 && len(p.XTestGoFiles) == 0 {
+			continue
+		}
+		names, err := extractTestNames(p.Dir, p.TestGoFiles, p.XTestGoFiles)
+		if err != nil {
+			return nil, err
+		}
+		if len(names) == 0 {
+			continue
+		}
+		sort.Strings(names)
+		lists = append(lists, testList{pkg: p.ImportPath, list: names})
+	}
+	sort.Slice(lists, func(i, j int) bool {
+		cmp := len(lists[i].list) - len(lists[j].list)
+		if cmp != 0 {
+			return cmp < 0
+		}
+		return strings.Compare(lists[i].pkg, lists[j].pkg) < 0
+	})
+	return lists, nil
+}

--- a/ast_list_test.go
+++ b/ast_list_test.go
@@ -1,0 +1,116 @@
+package gotesplit
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"testing"
+)
+
+// chdirT changes cwd and restores it after the test.
+func chdirT(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v (cwd=%s)", dir, err, orig)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+}
+
+func TestIsTestFunc(t *testing.T) {
+	testCases := []struct {
+		src    string
+		expect bool
+		desc   string
+	}{
+		{`package x; func TestFoo(t *testing.T) {}`, true, "regular Test"},
+		{`package x; func TestMain(t *testing.T) {}`, true, "TestMain taking *T is a regular test"},
+		{`package x; func TestX(t *foo.T) {}`, true, "renamed-import equivalent"},
+		{`package x; func TestMain(m *testing.M) {}`, false, "TestMain *M is entry point (drop)"},
+		{`package x; func BenchmarkFoo(b *testing.B) {}`, false, "Benchmark drops"},
+		{`package x; func FuzzFoo(f *testing.F) {}`, false, "Fuzz drops"},
+		{`package x; func Test() {}`, false, "prefix only"},
+		{`package x; func Testxxx(t *testing.T) {}`, false, "lowercase suffix"},
+		{`package x; func Bench() {}`, false, "not a test candidate"},
+		{`package x; func Helper() {}`, false, "not a test candidate"},
+		{`package x; func BenchmarkBad(s string) {}`, false, "invalid Benchmark silently drops"},
+		{`package x; func TestBad(s string) {}`, false, "invalid Test silently drops"},
+		{`package x; func TestExtra(t *testing.T, n int) {}`, false, "two parameters drops"},
+		{`package x; func TestMain(a, b *testing.M) {}`, false, "multi-name field drops"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fn := parseFuncDecl(t, tc.src)
+			got := isTestFunc(fn)
+			if got != tc.expect {
+				t.Errorf("expect: %v, got: %v", tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestASTvsGotestEquivalence(t *testing.T) {
+	chdirT(t, "testdata/ast_fixture")
+
+	testCases := []struct {
+		pkgs []string
+		tags string
+		race bool
+		desc string
+	}{
+		{[]string{"./simple"}, "", false, "simple"},
+		{[]string{"./examples"}, "", false, "examples"},
+		{[]string{"./withtags"}, "", false, "withtags-notag"},
+		{[]string{"./withtags"}, "-tags=a", true, "withtags-taga with -race"},
+		{[]string{"./racetag"}, "", false, "racetag-norace"},
+		{[]string{"./racetag"}, "", true, "racetag-race"},
+		{[]string{"./..."}, "", false, "multipkg"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expect, err := getTestListsFromPkgs(tc.pkgs, tc.tags, tc.race)
+			if err != nil {
+				t.Fatalf("gotest: unexpected error: %v", err)
+			}
+			got, err := getTestListsFromPkgsAST(tc.pkgs, tc.tags, tc.race)
+			if err != nil {
+				t.Fatalf("ast: unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(expect, got) {
+				t.Errorf("expect: %#v\ngot: %#v", expect, got)
+			}
+		})
+	}
+}
+
+func TestGetTestListsFromPkgsASTPackageError(t *testing.T) {
+	_, err := getTestListsFromPkgsAST([]string{"github.com/nonexistent/pkg-that-does-not-exist"}, "", false)
+	if err == nil {
+		t.Fatal("expect error for nonexistent package, got nil")
+	}
+}
+
+func parseFuncDecl(t *testing.T, src string) *ast.FuncDecl {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, d := range f.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok {
+			return fn
+		}
+	}
+	t.Fatal("no FuncDecl")
+	return nil
+}

--- a/cmd_regexp.go
+++ b/cmd_regexp.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 )
 
-type cmdRegexp struct{}
+type cmdRegexp struct {
+	mode listMode
+}
 
 func (c *cmdRegexp) run(ctx context.Context, argv []string, outStream io.Writer, errStream io.Writer) error {
 	// FIXME:
@@ -26,7 +28,7 @@ func (c *cmdRegexp) run(ctx context.Context, argv []string, outStream io.Writer,
 		return fmt.Errorf("invalid index: %s", err)
 	}
 
-	str, err := getOut(pkgs, detectTags(argv), detectRace(argv), total, idx)
+	str, err := getOut(pkgs, detectTags(argv), detectRace(argv), total, idx, c.mode)
 	if err != nil {
 		return err
 	}
@@ -34,14 +36,21 @@ func (c *cmdRegexp) run(ctx context.Context, argv []string, outStream io.Writer,
 	return err
 }
 
-func getOut(pkgs []string, tags string, withRace bool, total, idx int) (string, error) {
+func getOut(pkgs []string, tags string, withRace bool, total, idx int, mode listMode) (string, error) {
 	if total < 1 {
 		return "", fmt.Errorf("invalid total: %d", total)
 	}
 	if idx >= total {
 		return "", fmt.Errorf("index shoud be between 0 to total-1, but: %d (total:%d)", idx, total)
 	}
-	testLists, err := getTestListsFromPkgs(pkgs, tags, withRace)
+	var testLists []testList
+	var err error
+	switch mode {
+	case listModeAST:
+		testLists, err = getTestListsFromPkgsAST(pkgs, tags, withRace)
+	default:
+		testLists, err = getTestListsFromPkgs(pkgs, tags, withRace)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/gotesplit.go
+++ b/gotesplit.go
@@ -16,6 +16,24 @@ import (
 
 const cmdName = "gotesplit"
 
+type listMode int
+
+const (
+	listModeGotest listMode = iota
+	listModeAST
+)
+
+func parseListMode(s string) (listMode, error) {
+	switch s {
+	case "", "gotest":
+		return listModeGotest, nil
+	case "ast":
+		return listModeAST, nil
+	default:
+		return 0, fmt.Errorf("unknown -list-mode: %q (must be gotest or ast)", s)
+	}
+}
+
 // Run the gotesplit
 func Run(ctx context.Context, argv []string, outStream, errStream io.Writer) error {
 	log.SetOutput(errStream)
@@ -41,6 +59,7 @@ Options:
 	index := fs.Uint("index", 0, "zero-based index number of test splits (CIRCLE_NODE_INDEX is used if set)")
 	junitDir := fs.String("junit-dir", "", "directory to store test result in JUnit format")
 	coverprofileDir := fs.String("coverprofile-dir", ".cover", "temporary directory for collecting coverprofile")
+	listModeStr := fs.String("list-mode", "gotest", "test listing mode: gotest (use 'go test -list') or ast (use static AST analysis)")
 	fs.VisitAll(func(f *flag.Flag) {
 		if f.Name == "index" || f.Name == "total" {
 			if s := os.Getenv("CIRCLE_NODE_" + strings.ToUpper(f.Name)); s != "" {
@@ -51,14 +70,18 @@ Options:
 	if err := fs.Parse(argv); err != nil {
 		return err
 	}
+	mode, err := parseListMode(*listModeStr)
+	if err != nil {
+		return err
+	}
 	argv = fs.Args()
 	if len(argv) > 0 {
-		rnr, ok := dispatch[argv[0]]
+		rnr, ok := dispatch(mode)[argv[0]]
 		if ok {
 			return rnr.run(ctx, argv[1:], outStream, errStream)
 		}
 	}
-	return run(ctx, *total, *index, *junitDir, *coverprofileDir, argv, outStream, errStream)
+	return run(ctx, *total, *index, mode, *junitDir, *coverprofileDir, argv, outStream, errStream)
 }
 
 func getTestListsFromPkgs(pkgs []string, tags string, withRace bool) ([]testList, error) {

--- a/gotesplit_test.go
+++ b/gotesplit_test.go
@@ -1,7 +1,6 @@
 package gotesplit
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
@@ -149,10 +148,7 @@ func TestDetectRace(t *testing.T) {
 }
 
 func TestGetTestListFromPkgs(t *testing.T) {
-	if err := os.Chdir("testdata/withtags"); err != nil {
-		wd, _ := os.Getwd()
-		t.Fatalf("unexpected error: %v, cwd: %s", err, wd)
-	}
+	chdirT(t, "testdata/withtags")
 
 	expect := []testList{{
 		pkg: "github.com/Songmu/gotesplit/testdata/withtags",
@@ -171,3 +167,4 @@ func TestGetTestListFromPkgs(t *testing.T) {
 		t.Errorf("expect: %#v\ngot: %#v", expect, got)
 	}
 }
+

--- a/run.go
+++ b/run.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func run(_ context.Context, total, idx uint, junitDir string, coverprofilesDir string, argv []string, outStream io.Writer, errStream io.Writer) error {
+func run(_ context.Context, total, idx uint, mode listMode, junitDir string, coverprofilesDir string, argv []string, outStream io.Writer, errStream io.Writer) error {
 	if idx >= total {
 		return fmt.Errorf("`index` should be the range from 0 to `total`-1, but: %d (total:%d)", idx, total)
 	}
@@ -54,7 +54,14 @@ func run(_ context.Context, total, idx uint, junitDir string, coverprofilesDir s
 		}
 	}
 
-	testLists, err := getTestListsFromPkgs(pkgs, detectTags(testOpts), detectRace(testOpts))
+	var testLists []testList
+	var err error
+	switch mode {
+	case listModeAST:
+		testLists, err = getTestListsFromPkgsAST(pkgs, detectTags(testOpts), detectRace(testOpts))
+	default:
+		testLists, err = getTestListsFromPkgs(pkgs, detectTags(testOpts), detectRace(testOpts))
+	}
 	if err != nil {
 		return err
 	}

--- a/runner.go
+++ b/runner.go
@@ -5,10 +5,12 @@ import (
 	"io"
 )
 
-var dispatch = map[string]runner{
-	"regexp": &cmdRegexp{},
-}
-
 type runner interface {
 	run(context.Context, []string, io.Writer, io.Writer) error
+}
+
+func dispatch(mode listMode) map[string]runner {
+	return map[string]runner{
+		"regexp": &cmdRegexp{mode: mode},
+	}
 }

--- a/testdata/ast_fixture/examples/examples.go
+++ b/testdata/ast_fixture/examples/examples.go
@@ -1,0 +1,3 @@
+package examples
+
+func Hello() string { return "hi" }

--- a/testdata/ast_fixture/examples/examples_test.go
+++ b/testdata/ast_fixture/examples/examples_test.go
@@ -1,0 +1,26 @@
+package examples
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRegular(t *testing.T) {}
+
+func Example_withOutput() {
+	fmt.Println(Hello())
+	// Output: hi
+}
+
+func Example_noOutput() {
+	// no output comment, go test won't run this
+	_ = Hello()
+}
+
+func Example_unordered() {
+	fmt.Println("a")
+	fmt.Println("b")
+	// Unordered output:
+	// b
+	// a
+}

--- a/testdata/ast_fixture/go.mod
+++ b/testdata/ast_fixture/go.mod
@@ -1,0 +1,3 @@
+module github.com/Songmu/gotesplit/testdata/ast_fixture
+
+go 1.23

--- a/testdata/ast_fixture/racetag/normal_test.go
+++ b/testdata/ast_fixture/racetag/normal_test.go
@@ -1,0 +1,5 @@
+package racetag
+
+import "testing"
+
+func TestNormal(t *testing.T) {}

--- a/testdata/ast_fixture/racetag/race_test.go
+++ b/testdata/ast_fixture/racetag/race_test.go
@@ -1,0 +1,7 @@
+//go:build race
+
+package racetag
+
+import "testing"
+
+func TestOnlyRace(t *testing.T) {}

--- a/testdata/ast_fixture/racetag/racetag.go
+++ b/testdata/ast_fixture/racetag/racetag.go
@@ -1,0 +1,1 @@
+package racetag

--- a/testdata/ast_fixture/simple/simple.go
+++ b/testdata/ast_fixture/simple/simple.go
@@ -1,0 +1,3 @@
+package simple
+
+func Hello() string { return "hello" }

--- a/testdata/ast_fixture/simple/simple_test.go
+++ b/testdata/ast_fixture/simple/simple_test.go
@@ -1,0 +1,15 @@
+package simple
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestA(t *testing.T) {}
+func TestB(t *testing.T) {}
+func TestMain(m *testing.M) { os.Exit(m.Run()) }
+func ExampleHello() {
+	fmt.Println(Hello())
+	// Output: hello
+}

--- a/testdata/ast_fixture/withtags/notag_test.go
+++ b/testdata/ast_fixture/withtags/notag_test.go
@@ -1,0 +1,5 @@
+package withtags
+
+import "testing"
+
+func TestNoTag(t *testing.T) {}

--- a/testdata/ast_fixture/withtags/tag_a_test.go
+++ b/testdata/ast_fixture/withtags/tag_a_test.go
@@ -1,0 +1,7 @@
+//go:build a
+
+package withtags
+
+import "testing"
+
+func TestTagA(t *testing.T) {}

--- a/testdata/ast_fixture/withtags/withtags.go
+++ b/testdata/ast_fixture/withtags/withtags.go
@@ -1,0 +1,1 @@
+package withtags


### PR DESCRIPTION
Hi,

While using gotesplit on a repo with some very large packages, I noticed that the `go test -list .` step compiles every target package, and that cost is paid in every shard. This PR adds a `-list-mode=ast` option that extracts test names by statically parsing `_test.go` files, skipping the compile and `TestMain` execution entirely. The default (`-list-mode=gotest`) is unchanged.

A few implementation notes:

- Test/Benchmark/Fuzz/TestMain classification mirrors cmd/go's [`isTestFunc`](https://github.com/golang/go/blob/master/src/cmd/go/internal/load/test.go#L551).
- Example detection is delegated to `go/doc.Examples` (the same library cmd/go uses).
- Build-tag and `-race` evaluation is delegated to the Go toolchain by invoking `go list -json -e [-tags=...] [-race]`.
- The equivalence test under `testdata/ast_fixture/` checks that the AST output matches `go test -list` across simple/examples/build-tag/race scenarios.

That said, I am aware that AST-based extraction is strictly less accurate than running the actual test binary. I have tried to align with cmd/go behavior, but edge cases (for example, tests dynamically registered via a custom `testing.MainStart`) can diverge. I would totally understand if you would rather not take that trade-off.

I would love to hear your thoughts. Happy to iterate or drop the PR if it does not fit.

Thanks!
