### PR TITLE
Modernize GitHub Actions workflows and CI configuration

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -11,12 +11,15 @@ runs:
   using: composite
   steps:
   - name: setup go
-    uses: actions/setup-go@v4
+    uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
     with:
       go-version-file: go.mod
-  - name: release
-    run: |
-      make crossbuild upload
+  - name: crossbuild
+    run: make crossbuild
     shell: bash
-    env:
-      GITHUB_TOKEN: ${{ inputs.token }}
+  - name: upload
+    uses: tcnksm/ghr@766f869eacbbb086e8860cf0f0192dda6e8e67e1 # v0.18.3
+    with:
+      tag: ${{ inputs.tag || github.ref_name }}
+      path: dist
+      token: ${{ inputs.token }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+      - go
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,12 +3,18 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
+permissions:
+  contents: write
+  packages: write
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: ./.github/actions/release
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -1,31 +1,39 @@
 name: reviewdog
 on: [pull_request]
-
 jobs:
   staticcheck:
     name: staticcheck
+    permissions:
+      contents: read
+      pull-requests: write
+
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: staticcheck
-        uses: reviewdog/action-staticcheck@v1
+        uses: reviewdog/action-staticcheck@50f9bfcf3738839ddc95deac241b904d77469096 # v1.28.0
         with:
           reporter: github-pr-review
           level: warning
 
   misspell:
     name: misspell
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: misspell
-        uses: reviewdog/action-misspell@v1
+        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
         with:
           reporter: github-pr-review
           level: warning
@@ -33,10 +41,14 @@ jobs:
 
   actionlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: reviewdog/action-actionlint@v1
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           reporter: github-pr-review

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -3,19 +3,23 @@ on:
   push:
     branches:
     - "main"
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
 jobs:
   tagpr:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: checkout
-      uses: actions/checkout@v3
-    - name: setup go
-      uses: actions/setup-go@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        go-version-file: go.mod
+        persist-credentials: false
     - name: tagpr
       id: tagpr
-      uses: Songmu/tagpr@v1
+      uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: ./.github/actions/release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,18 @@
 name: test
 on:
-  push:
+  pull_request:
     branches:
     - "**"
+  push:
+    branches:
+    - main
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -15,14 +22,19 @@ jobs:
         - windows-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: setup go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
     - name: test
-      run: go test -race -coverprofile coverage.out -covermode atomic
+      run: |
+        # avoid 'no such tool "covdata"' error
+        go env -w GOTOOLCHAIN=go1.25.0+auto
+        go test -coverprofile coverage.out -covermode atomic ./...
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}
     - name: Send coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1

--- a/CREDITS
+++ b/CREDITS
@@ -1,7 +1,7 @@
 Go (the standard library)
 https://golang.org/
 ----------------------------------------------------------------
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -13,7 +13,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 
@@ -93,7 +93,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 golang.org/x/sync
 https://golang.org/x/sync
 ----------------------------------------------------------------
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -105,7 +105,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ u := $(if $(update),-u)
 
 .PHONY: deps
 deps:
-	go get ${u} -d
+	go get ${u}
 	go mod tidy
 
 .PHONY: devel-deps

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ deps:
 .PHONY: devel-deps
 devel-deps:
 	go install github.com/Songmu/godzil/cmd/godzil@latest
-	go install github.com/tcnksm/ghr@latest
 
 .PHONY: test
 test:
@@ -39,7 +38,3 @@ crossbuild: CREDITS
 	env CGO_ENABLED=0 godzil crossbuild -pv=v$(VERSION) -build-ldflags=$(BUILD_LDFLAGS) \
       -os=linux,darwin,windows -d=$(DIST_DIR) ./cmd/*
 	cd $(DIST_DIR) && shasum -a 256 $$(find * -type f -maxdepth 0) > SHA256SUMS
-
-.PHONY: upload
-upload:
-	ghr v$(VERSION) $(DIST_DIR)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/Songmu/gotesplit
 
-go 1.23
+go 1.25.0
+
+toolchain go1.26.3
 
 require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
-	golang.org/x/sync v0.8.0
+	golang.org/x/sync v0.20.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
 github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=


### PR DESCRIPTION
## Changes

- Pin all actions to commit hashes for supply chain security
- Add explicit permissions with least privilege principle
- Add `timeout-minutes` to all jobs
- Add `persist-credentials: false` to all checkouts
- Add `workflow_dispatch` trigger to tagpr
- Change test trigger to `pull_request` + `push` to main
- Add GOTOOLCHAIN workaround for covdata tool error
- Use `tcnksm/ghr` action for release uploads instead of CLI
- Remove ghr CLI dependency and `upload` Make target
- Update CREDITS copyright notices
- Add `dependabot.yml` for gomod and github-actions updates